### PR TITLE
pom update.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,13 +133,13 @@
 
     <repositories>
         <repository>
-            <id>scala-tools.org</id>
+            <id>scala-tools.org-snapshots</id>
             <name>Scala-Tools Maven2 Repository</name>
             <url>http://scala-tools.org/repo-snapshots/</url>
         </repository>
 
         <repository>
-            <id>scala-tools.org</id>
+            <id>scala-tools.org-releases</id>
             <name>Scala-Tools Maven2 Repository</name>
             <url>http://scala-tools.org/repo-releases/</url>
         </repository>
@@ -178,27 +178,55 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.1</version>
+            <exclusions>
+              <exclusion>
+                <groupId>avalon-framework</groupId>
+                <artifactId>avalon-framework</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>logkit</groupId>
+                <artifactId>logkit</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+              </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.5.8</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.5.8</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <version>1.5.8</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.14</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Reduce the required dependencies needed so they don't pollute the classpath of projects which depend on cascal. 
